### PR TITLE
chore(ci): Tweak publish workflow for OSSRH

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -26,7 +26,7 @@ jobs:
         uses: gradle/wrapper-validation-action@v1
 
       - name: Publish package
-        run: ./gradlew publish
+        run: ./gradlew publish --stacktrace
         env:
           OSSRH_USER: ${{ secrets.OSSRH_USER }}
           OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -29,10 +29,10 @@ jobs:
         uses: gradle/wrapper-validation-action@v1
 
       - name: Publish package
-        run: ./gradlew publish --stacktrace
-        env:
-          OSSRH_USER: '${{ secrets.OSSRH_USER }}'
-          OSSRH_PASSWORD: '${{ secrets.OSSRH_PASSWORD }}'
-          OSSRH_SIGNING_KEY_ID: '${{ secrets.OSSRH_SIGNING_KEY_ID }}'
-          OSSRH_SIGNING_KEY: '${{ secrets.OSSRH_SIGNING_KEY }}'
-          OSSRH_SIGNING_PASSWORD: '${{ secrets.OSSRSH_SIGNING_PASSWORD }}'
+        run: |-
+          ./gradlew publish \
+          -Possrh.user='${{ secrets.OSSRH_USER}}' \
+          -Possrh.password='${{ secrets.OSSRH_PASSWORD }}' \
+          -Possrh.signing.key_id='${{ secrets.OSSRH_SIGNING_KEY_ID }}' \
+          -Possrh.signing.password='${{ secrets.OSSRH_SIGNING_PASSWORD }}' \
+          -Possrh.signing.key='${{ secrets.OSSRH_SIGNING_KEY }}' --stacktrace

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -2,9 +2,6 @@
 name: Publish
 on:
   workflow_dispatch:
-  pull_request:
-    branches:
-      - '*'
   push:
     branches:
       - main

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -2,6 +2,9 @@
 name: Publish
 on:
   workflow_dispatch:
+  pull_request:
+    branches:
+      - '*'
   push:
     branches:
       - main

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -31,8 +31,8 @@ jobs:
       - name: Publish package
         run: ./gradlew publish --stacktrace
         env:
-          OSSRH_USER: ${{ secrets.OSSRH_USER }}
-          OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
-          OSSRH_SIGNING_KEY_ID: ${{ secrets.OSSRH_SIGNING_KEY_ID }}
-          OSSRH_SIGNING_KEY: ${{ secrets.OSSRH_SIGNING_KEY }}
-          OSSRH_SIGNING_PASSWORD: ${{ secrets.OSSRSH_SIGNING_PASSWORD }}
+          OSSRH_USER: '${{ secrets.OSSRH_USER }}'
+          OSSRH_PASSWORD: '${{ secrets.OSSRH_PASSWORD }}'
+          OSSRH_SIGNING_KEY_ID: '${{ secrets.OSSRH_SIGNING_KEY_ID }}'
+          OSSRH_SIGNING_KEY: '${{ secrets.OSSRH_SIGNING_KEY }}'
+          OSSRH_SIGNING_PASSWORD: '${{ secrets.OSSRSH_SIGNING_PASSWORD }}'

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -33,5 +33,6 @@ jobs:
         env:
           OSSRH_USER: ${{ secrets.OSSRH_USER }}
           OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+          OSSRH_SIGNING_KEY_ID: ${{ secrets.OSSRH_SIGNING_KEY_ID }}
           OSSRH_SIGNING_KEY: ${{ secrets.OSSRH_SIGNING_KEY }}
           OSSRH_SIGNING_PASSWORD: ${{ secrets.OSSRSH_SIGNING_PASSWORD }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -90,7 +90,7 @@ publishing {
             )
             credentials {
                 username = project.findProperty("ossrh.user") as String? ?: System.getenv("OSSRH_USER")
-                password = project.findProperty("ossrh.token") as String? ?: System.getenv("OSSRH_PASSWORD")
+                password = project.findProperty("ossrh.password") as String? ?: System.getenv("OSSRH_PASSWORD")
             }
         }
     }
@@ -122,9 +122,10 @@ publishing {
 }
 
 signing {
-    val signingKeyId = System.getenv("OSSRH_SIGNING_KEY_ID")
-    val signingKey = System.getenv("OSSRH_SIGNING_KEY")
-    val signingPassword = System.getenv("OSSRH_SIGNING_PASSWORD")
+    val signingKeyId = project.findProperty("ossrh.signing.key_id") as String? ?: System.getenv("OSSRH_SIGNING_KEY_ID")
+    val signingKey = project.findProperty("ossrh.signing.key") as String? ?: System.getenv("OSSRH_SIGNING_KEY")
+    val signingPassword =
+        project.findProperty("ossrh.signing.password") as String? ?: System.getenv("OSSRH_SIGNING_PASSWORD")
     useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
     sign(publishing.publications["ossrh"])
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -122,8 +122,9 @@ publishing {
 }
 
 signing {
+    val signingKeyId = System.getenv("OSSRH_SIGNING_KEY_ID")
     val signingKey = System.getenv("OSSRH_SIGNING_KEY")
     val signingPassword = System.getenv("OSSRH_SIGNING_PASSWORD")
-    useInMemoryPgpKeys(signingKey, signingPassword)
+    useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
     sign(publishing.publications["ossrh"])
 }


### PR DESCRIPTION
Use Gradle properties to read GPG key because environment variables get mangled for some reason.
