### PR TITLE
chore: Strip the `v` from version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,10 +20,11 @@ val gitVersion: groovy.lang.Closure<String> by extra
 val projectVersion: String by lazy {
     val versionDetails: groovy.lang.Closure<com.palantir.gradle.gitversion.VersionDetails> by extra
     with(versionDetails()) {
+        val version = lastTag.removePrefix("v")
         if (commitDistance > 0) {
-            val tokens = lastTag.split('.')
+            val tokens = version.split('.')
             "${tokens[0]}.${tokens[1]}.${tokens[2].toInt() + 1}-SNAPSHOT"
-        } else lastTag
+        } else version
     }
 }
 group = "dev.cerbos"


### PR DESCRIPTION
We derive the version from the git tag but we should strip out the `v`
prefix because Java packages usually don't include prefixes.

Fixes #30

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
