### PR TITLE
enhancement: Add getters for request and call IDs

### DIFF
--- a/src/main/java/dev/cerbos/sdk/CerbosBlockingClient.java
+++ b/src/main/java/dev/cerbos/sdk/CerbosBlockingClient.java
@@ -116,9 +116,9 @@ public class CerbosBlockingClient {
     try {
       Response.CheckResourcesResponse response = withClient().checkResources(request);
       if (response.getResultsCount() == 1) {
-        return new CheckResult(response.getResults(0));
+        return new CheckResult(response.getRequestId(), response.getCerbosCallId(), response.getResults(0));
       }
-      return new CheckResult(null);
+      return new CheckResult(response.getRequestId(), response.getCerbosCallId(), null);
     } catch (StatusRuntimeException sre) {
       throw new CerbosException(sre.getStatus(), sre.getCause());
     }

--- a/src/main/java/dev/cerbos/sdk/CheckResourcesResult.java
+++ b/src/main/java/dev/cerbos/sdk/CheckResourcesResult.java
@@ -12,44 +12,52 @@ import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 public class CheckResourcesResult {
-  private final Response.CheckResourcesResponse resp;
+    private final Response.CheckResourcesResponse resp;
 
-  CheckResourcesResult(Response.CheckResourcesResponse resp) {
-    this.resp = resp;
-  }
+    CheckResourcesResult(Response.CheckResourcesResponse resp) {
+        this.resp = resp;
+    }
 
-  public Stream<CheckResult> results() {
-    return this.resp.getResultsList().stream().map(CheckResult::new);
-  }
+    public Stream<CheckResult> results() {
+        return this.resp.getResultsList().stream().map( entry -> new CheckResult(resp.getRequestId(), resp.getCerbosCallId(), entry));
+    }
 
-  public Optional<CheckResult> find(String resourceID) {
-    return find(resourceID, null);
-  }
+    public Optional<CheckResult> find(String resourceID) {
+        return find(resourceID, null);
+    }
 
-  public Optional<CheckResult> find(
-      String resourceID,
-      Predicate<Response.CheckResourcesResponse.ResultEntry.Resource> predicate) {
-    return this.resp.getResultsList().stream()
-        .filter(
-            re -> {
-              if (!re.getResource().getId().equals(resourceID)) {
-                return false;
-              }
-              if (predicate != null) {
-                return predicate.test(re.getResource());
-              }
+    public Optional<CheckResult> find(
+            String resourceID,
+            Predicate<Response.CheckResourcesResponse.ResultEntry.Resource> predicate) {
+        return this.resp.getResultsList().stream()
+                .filter(
+                        re -> {
+                            if (!re.getResource().getId().equals(resourceID)) {
+                                return false;
+                            }
+                            if (predicate != null) {
+                                return predicate.test(re.getResource());
+                            }
 
-              return true;
-            })
-        .map(CheckResult::new)
-        .findFirst();
-  }
+                            return true;
+                        })
+                .map(entry -> new CheckResult(resp.getRequestId(), resp.getCerbosCallId(), entry))
+                .findFirst();
+    }
 
-  public boolean hasValidationErrors() {
-    return resp.getResultsList().stream().anyMatch(re -> re.getValidationErrorsCount() > 0);
-  }
+    public boolean hasValidationErrors() {
+        return resp.getResultsList().stream().anyMatch(re -> re.getValidationErrorsCount() > 0);
+    }
 
-  public Response.CheckResourcesResponse getRaw() {
-    return resp;
-  }
+    public Response.CheckResourcesResponse getRaw() {
+        return resp;
+    }
+
+    public String getRequestId() {
+        return this.resp.getRequestId();
+    }
+
+    public String getCerbosCallId() {
+        return this.resp.getCerbosCallId();
+    }
 }

--- a/src/main/java/dev/cerbos/sdk/CheckResult.java
+++ b/src/main/java/dev/cerbos/sdk/CheckResult.java
@@ -18,10 +18,22 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 public final class CheckResult {
+    private final String cerbosCallId;
+    private final String requestId;
     private final Response.CheckResourcesResponse.ResultEntry entry;
 
-    CheckResult(Response.CheckResourcesResponse.ResultEntry entry) {
+    CheckResult(String requestId, String cerbosCallId, Response.CheckResourcesResponse.ResultEntry entry) {
+        this.requestId = requestId;
+        this.cerbosCallId = cerbosCallId;
         this.entry = entry;
+    }
+
+    public String getRequestId() {
+        return this.requestId;
+    }
+
+    public String getCerbosCallId() {
+        return this.cerbosCallId;
     }
 
     /**

--- a/src/main/java/dev/cerbos/sdk/PlanResourcesResult.java
+++ b/src/main/java/dev/cerbos/sdk/PlanResourcesResult.java
@@ -13,49 +13,57 @@ import java.util.List;
 import java.util.Optional;
 
 public class PlanResourcesResult {
-  private final Response.PlanResourcesResponse resp;
+    private final Response.PlanResourcesResponse resp;
 
-  PlanResourcesResult(Response.PlanResourcesResponse resp) {
-    this.resp = resp;
-  }
+    PlanResourcesResult(Response.PlanResourcesResponse resp) {
+        this.resp = resp;
+    }
 
-  public String getAction() {
-    return this.resp.getAction();
-  }
+    public String getAction() {
+        return this.resp.getAction();
+    }
 
-  public String getResourceKind() {
-    return this.resp.getResourceKind();
-  }
+    public String getResourceKind() {
+        return this.resp.getResourceKind();
+    }
 
-  public String getPolicyVersion() {
-    return this.resp.getPolicyVersion();
-  }
+    public String getPolicyVersion() {
+        return this.resp.getPolicyVersion();
+    }
 
-  public boolean isAlwaysAllowed() {
-    return this.resp.getFilter().getKind() == Engine.PlanResourcesFilter.Kind.KIND_ALWAYS_ALLOWED;
-  }
+    public boolean isAlwaysAllowed() {
+        return this.resp.getFilter().getKind() == Engine.PlanResourcesFilter.Kind.KIND_ALWAYS_ALLOWED;
+    }
 
-  public boolean isAlwaysDenied() {
-    return this.resp.getFilter().getKind() == Engine.PlanResourcesFilter.Kind.KIND_ALWAYS_DENIED;
-  }
+    public boolean isAlwaysDenied() {
+        return this.resp.getFilter().getKind() == Engine.PlanResourcesFilter.Kind.KIND_ALWAYS_DENIED;
+    }
 
-  public boolean isConditional() {
-    return this.resp.getFilter().getKind() == Engine.PlanResourcesFilter.Kind.KIND_CONDITIONAL;
-  }
+    public boolean isConditional() {
+        return this.resp.getFilter().getKind() == Engine.PlanResourcesFilter.Kind.KIND_CONDITIONAL;
+    }
 
-  public Optional<Engine.PlanResourcesFilter.Expression.Operand> getCondition() {
-    return Optional.of(this.resp.getFilter().getCondition());
-  }
+    public Optional<Engine.PlanResourcesFilter.Expression.Operand> getCondition() {
+        return Optional.of(this.resp.getFilter().getCondition());
+    }
 
-  public boolean hasValidationErrors() {
-    return this.resp.getValidationErrorsCount() > 0;
-  }
+    public boolean hasValidationErrors() {
+        return this.resp.getValidationErrorsCount() > 0;
+    }
 
-  public List<SchemaOuterClass.ValidationError> getValidationErrors() {
-    return this.resp.getValidationErrorsList();
-  }
+    public List<SchemaOuterClass.ValidationError> getValidationErrors() {
+        return this.resp.getValidationErrorsList();
+    }
 
-  public Response.PlanResourcesResponse getRaw() {
-    return this.resp;
-  }
+    public Response.PlanResourcesResponse getRaw() {
+        return this.resp;
+    }
+
+    public String getRequestId() {
+        return this.resp.getRequestId();
+    }
+
+    public String getCerbosCallId() {
+        return this.resp.getCerbosCallId();
+    }
 }


### PR DESCRIPTION
Check and plan results now include `getCerbosCallId` and `getRequestId`
methods.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
