### PR TITLE
chore: Migrate to Maven Central Portal

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -3,8 +3,10 @@ name: Publish
 on:
   workflow_dispatch:
   push:
+    branches:
+      - "main"
     tags:
-      - '*'
+      - "*"
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -16,18 +18,20 @@ jobs:
 
       - uses: actions/setup-java@v4
         with:
-          java-version: '11'
-          distribution: 'temurin'
-          cache: 'gradle'
+          java-version: "17"
+          distribution: "temurin"
+          cache: "gradle"
 
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@v3
 
       - name: Publish package
+        env:
+          JRELEASER_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          JRELEASER_MAVENCENTRAL_USERNAME: ${{ secrets.JRELEASER_MAVENCENTRAL_USERNAME }}
+          JRELEASER_MAVENCENTRAL_PASSWORD: ${{ secrets.JRELEASER_MAVENCENTRAL_PASSWORD }}
+          JRELEASER_GPG_PASSPHRASE: ${{ secrets.JRELEASER_GPG_PASSPHRASE }}
+          JRELEASER_GPG_PUBLIC_KEY: ${{ secrets.JRELEASER_GPG_PUBLIC_KEY }}
+          JRELEASER_GPG_SECRET_KEY: ${{ secrets.JRELEASER_GPG_SECRET_KEY }}
         run: |-
-          ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository \
-          -Possrh.user='${{ secrets.OSSRH_USER}}' \
-          -Possrh.password='${{ secrets.OSSRH_PASSWORD }}' \
-          -Possrh.signing.key_id='${{ secrets.OSSRH_SIGNING_KEY_ID }}' \
-          -Possrh.signing.password='${{ secrets.OSSRH_SIGNING_PASSWORD }}' \
-          -Possrh.signing.key='${{ secrets.OSSRH_SIGNING_KEY }}' --stacktrace
+          ./gradlew jreleaserFullRelease

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,16 +11,16 @@ jobs:
       contents: read
     strategy:
       matrix:
-        java: ['11', '17']
+        java: ["17", "21"]
     name: "Java ${{ matrix.java }}"
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-java@v4
         with:
-          java-version: '${{ matrix.java }}'
-          distribution: 'temurin'
-          cache: 'gradle'
+          java-version: "${{ matrix.java }}"
+          distribution: "temurin"
+          cache: "gradle"
 
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@v3
@@ -36,7 +36,7 @@ jobs:
     steps:
       - id: setoutput
         run: |-
-         echo "::set-output name=success::true"
+          echo "::set-output name=success::true"
 
   testSuccess:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The OSSRH repository is being discontinued in June and all projects
should be migrated to the new Maven Central Portal.

Also sets the minimum Java version to 17 which is the oldest supported
Java version at the moment.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
