### PR TITLE
chore: Rename Hub listFiles `like` filter to `contains`

### DIFF
--- a/src/main/java/dev/cerbos/sdk/hub/Store.java
+++ b/src/main/java/dev/cerbos/sdk/hub/Store.java
@@ -261,15 +261,15 @@ public final class Store {
         }
 
         /**
-         * Sets the filter to match the given path pattern.
+         * Sets the filter to match paths that contain the given fragment.
          *
-         * @param pattern Pattern to match
+         * @param fragment Fragment to match
          * @return {@link ListFilesRequest}
          */
-        public ListFilesRequest setPathMustBeLike(String pattern) {
+        public ListFilesRequest setPathMustContain(String fragment) {
             builder.setFilter(
                     dev.cerbos.api.cloud.v1.store.Store.FileFilter.newBuilder()
-                            .setPath(dev.cerbos.api.cloud.v1.store.Store.StringMatch.newBuilder().setLike(pattern).build())
+                            .setPath(dev.cerbos.api.cloud.v1.store.Store.StringMatch.newBuilder().setContains(fragment).build())
                             .build()
             );
 

--- a/src/main/proto/cerbos/cloud/store/v1/store.proto
+++ b/src/main/proto/cerbos/cloud/store/v1/store.proto
@@ -27,7 +27,7 @@ message StringMatch {
   oneof match {
     option (buf.validate.oneof).required = true;
     string equals = 1;
-    string like = 2;
+    string contains = 2;
     InList in = 3;
   }
 }

--- a/src/test/java/dev/cerbos/sdk/hub/CerbosHubStoreClientTest.java
+++ b/src/test/java/dev/cerbos/sdk/hub/CerbosHubStoreClientTest.java
@@ -271,7 +271,7 @@ public class CerbosHubStoreClientTest {
     public class ListFiles {
         @Test
         public void fileFilterMatches() throws StoreException {
-            Store.ListFilesResponse resp = client.listFiles(Store.newListFilesRequest(storeID).setPathMustBeLike("export_"));
+            Store.ListFilesResponse resp = client.listFiles(Store.newListFilesRequest(storeID).setPathMustContain("export_"));
             List<String> want = List.of("export_constants/export_constants_01.yaml", "export_variables/export_variables_01.yaml");
             Assertions.assertIterableEquals(want, resp.getFilesList());
         }


### PR DESCRIPTION
Signed-off-by: Charith Ellawala <charith@cerbos.dev>
